### PR TITLE
Add test for multiple flashes

### DIFF
--- a/src/Yurly/Inject/Request/RequestFoundation.php
+++ b/src/Yurly/Inject/Request/RequestFoundation.php
@@ -19,7 +19,7 @@ abstract class RequestFoundation
         $this->context = $context;
 
         // Attempt to guess the type
-        if ($this->context->getUrl()->requestMethod) {
+        if ($this->context->getUrl() && $this->context->getUrl()->requestMethod) {
             $this->type = ucfirst(strtolower($this->context->getUrl()->requestMethod));
         } else {
             $this->type = 'Unknown';

--- a/src/Yurly/Inject/Response/ResponseFoundation.php
+++ b/src/Yurly/Inject/Response/ResponseFoundation.php
@@ -135,7 +135,7 @@ abstract class ResponseFoundation
         }
 
         if (isset($_SESSION['YURLY.flash'])) {
-            $flash = json_decode($_SESSION['YURLY.flash']);
+            $flash = json_decode($_SESSION['YURLY.flash'], true);
         } else {
             $flash = [];
         }

--- a/tests/Tests/ResponseTest.php
+++ b/tests/Tests/ResponseTest.php
@@ -3,20 +3,19 @@
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;
-use Yurly\Request\Request;
 
 class ResponseTest extends TestCase
 {
     public function testFlashWithMultipleKeys()
     {
-        $project = new \Yurly\Core\Project(__NAMESPACE__, 'tests', true);
+        $project = new \Yurly\Core\Project('',__NAMESPACE__, 'tests');
         $ctx = new \Yurly\Core\Context($project);
-        $response = new \Yurly\Response\Response($ctx);
+        $response = new \Yurly\Inject\Response\Response($ctx);
 
         $response->flash('first_key', 'first_value');
         $response->flash('second_key', 'second_value');
 
-        $request = new Request($ctx);
+        $request = new \Yurly\Inject\Request\Request($ctx);
         $this->assertEquals('first_value', $request->getFlash('first_key'));
         $this->assertEquals('second_value', $request->getFlash('second_key'));
     }

--- a/tests/Tests/ResponseTest.php
+++ b/tests/Tests/ResponseTest.php
@@ -3,9 +3,23 @@
 namespace Tests;
 
 use PHPUnit\Framework\TestCase;
+use Yurly\Request\Request;
 
 class ResponseTest extends TestCase
 {
+    public function testFlashWithMultipleKeys()
+    {
+        $project = new \Yurly\Core\Project(__NAMESPACE__, 'tests', true);
+        $ctx = new \Yurly\Core\Context($project);
+        $response = new \Yurly\Response\Response($ctx);
+
+        $response->flash('first_key', 'first_value');
+        $response->flash('second_key', 'second_value');
+
+        $request = new Request($ctx);
+        $this->assertEquals('first_value', $request->getFlash('first_key'));
+        $this->assertEquals('second_value', $request->getFlash('second_key'));
+    }
 
     public function testResponseInterface()
     {


### PR DESCRIPTION
If second parameter is not set to true in json_decode it will decode it as an object and will always overwrite it when a second flash happens.